### PR TITLE
Serve MLB predictions CSV to frontend

### DIFF
--- a/backend/mlb_pred_pipeline.py
+++ b/backend/mlb_pred_pipeline.py
@@ -14,7 +14,8 @@ def predict_and_odds(date: str, bankroll: float, kelly: float, min_edge: float, 
     odds_df = get_game_odds_today()
 
     merged = pred_df.merge(odds_df, on=["Team"], how="left")
-    merged.drop(columns=["home_team", "away_team"], inplace=True)
+    # Keep home_team and away_team columns so downstream consumers can
+    # reconstruct full matchups from the CSV output.
 
     merged["Implied_Odds"] = (1 / merged["Odds"]).round(3)
     merged["Edge"] = (merged["Model_Prob"] - merged["Implied_Odds"]).round(3)

--- a/backend/src/odds.py
+++ b/backend/src/odds.py
@@ -29,14 +29,17 @@ def get_game_odds_today() -> pd.DataFrame:
     }
     resp = requests.get(url, params=params)
     odds_data = resp.json()
-    odds_df = pd.json_normalize(odds_data,
+    odds_df = pd.json_normalize(
+        odds_data,
         record_path=["bookmakers", "markets", "outcomes"],
         meta=[
-        ["bookmakers","title"],
-        ["bookmakers","last_update"],
-        "home_team","away_team"
-        ]
-    ).rename(columns={"price":"Odds","name":"Team","bookmakers.title":"Book"})
+            ["bookmakers", "title"],
+            ["bookmakers", "last_update"],
+            "commence_time",
+            "home_team",
+            "away_team",
+        ],
+    ).rename(columns={"price": "Odds", "name": "Team", "bookmakers.title": "Book"})
     
     odds_df["Team"] = odds_df["Team"].str.replace(
         "Oakland Athletics", "Athletics", regex=False
@@ -46,9 +49,11 @@ def get_game_odds_today() -> pd.DataFrame:
     )
     
     odds_df['Team'] = odds_df["Team"].map(full_to_abbrev)
-    
-    #print(odds_df)
-    #odds_df.to_csv("data/processed/odds.csv", index=False)
+    odds_df["home_team"] = odds_df["home_team"].map(full_to_abbrev)
+    odds_df["away_team"] = odds_df["away_team"].map(full_to_abbrev)
+
+    # print(odds_df)
+    # odds_df.to_csv("data/processed/odds.csv", index=False)
     return odds_df
 
 def suggest_units(

--- a/package.json
+++ b/package.json
@@ -2,5 +2,8 @@
   "dependencies": {
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.539.0"
+  },
+  "scripts": {
+    "start": "node server.js"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,80 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 3001;
+
+function parseCsv(str) {
+  const lines = str.trim().split(/\r?\n/);
+  if (!lines.length) return [];
+  const headers = lines[0].split(',');
+  return lines.slice(1).filter(Boolean).map(line => {
+    const values = line.split(',');
+    const obj = {};
+    headers.forEach((h, i) => { obj[h] = values[i]; });
+    return obj;
+  });
+}
+
+function decimalToAmerican(dec) {
+  const d = Number(dec);
+  if (!isFinite(d)) return undefined;
+  if (d >= 2) return Math.round((d - 1) * 100);
+  return Math.round(-100 / (d - 1));
+}
+
+function handlePredictions(req, res) {
+  const filePath = path.join(__dirname, 'backend', 'data', 'processed', 'games_today.csv');
+  try {
+    const csv = fs.readFileSync(filePath, 'utf8');
+    const rows = parseCsv(csv);
+    const grouped = {};
+    rows.forEach(r => {
+      const gid = r.game_id;
+      if (!grouped[gid]) {
+        grouped[gid] = { game_id: gid, commence_time: r.commence_time, home_team: r.home_team, away_team: r.away_team, rows: [] };
+      }
+      grouped[gid].rows.push(r);
+    });
+    const predictions = Object.values(grouped).map(g => {
+      const homeRow = g.rows.find(r => r.Team === g.home_team);
+      const awayRow = g.rows.find(r => r.Team === g.away_team);
+      return {
+        game_id: g.game_id,
+        start_time_utc: g.commence_time || null,
+        league: 'MLB',
+        home_team: g.home_team,
+        away_team: g.away_team,
+        model: 'mlb_moneyline_v1',
+        home_ml_prob: homeRow ? Number(homeRow.Model_Prob) : undefined,
+        away_ml_prob: awayRow ? Number(awayRow.Model_Prob) : undefined,
+        home_book_odds: homeRow ? decimalToAmerican(homeRow.Odds) : undefined,
+        away_book_odds: awayRow ? decimalToAmerican(awayRow.Odds) : undefined,
+        edge_home: homeRow && homeRow.Edge ? Number(homeRow.Edge) * 100 : undefined,
+        edge_away: awayRow && awayRow.Edge ? Number(awayRow.Edge) * 100 : undefined,
+        note: null,
+      };
+    });
+    const stat = fs.statSync(filePath);
+    const body = JSON.stringify({ predictions, last_updated: stat.mtime.toISOString() });
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(body);
+  } catch (err) {
+    console.error(err);
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Failed to load predictions' }));
+  }
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url && req.url.startsWith('/api/mlb/predictions')) {
+    handlePredictions(req, res);
+  } else {
+    res.statusCode = 404;
+    res.end('Not found');
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- keep home/away teams in MLB prediction CSV
- enrich odds data with commence times and team abbreviations
- add minimal Node HTTP server exposing `/api/mlb/predictions`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python -m py_compile backend/mlb_pred_pipeline.py backend/src/odds.py`
- `node --check server.js && echo "syntax ok"`
- `cd my-app && npm test` *(fails: Missing script: "test")*
- `cd my-app && npm run lint` *(fails: 3 errors)*


------
https://chatgpt.com/codex/tasks/task_e_689e44818e94833388602d6abbbc0fcd