### PR TITLE
Serve MLB predictions from Supabase

### DIFF
--- a/backend/src/supabase_client.py
+++ b/backend/src/supabase_client.py
@@ -29,3 +29,28 @@ def upsert_predictions(df: pd.DataFrame, table: str = "mlb_predictions") -> None
     records = df.where(pd.notnull(df), None).to_dict("records")
     if records:
         _client.table(table).upsert(records).execute()
+
+
+def upload_file(
+    local_path: str,
+    bucket: str = "mlb-data",
+    dest_path: Optional[str] = None,
+) -> None:
+    """Upload a local file to a Supabase storage bucket.
+
+    Parameters
+    ----------
+    local_path: str
+        Path to the local file to upload.
+    bucket: str
+        Name of the Supabase storage bucket.
+    dest_path: Optional[str]
+        Path (including filename) to store within the bucket. If omitted,
+        the file's basename is used.
+    """
+    if _client is None:
+        raise RuntimeError("Supabase client is not configured. Set SUPABASE_URL and SUPABASE_KEY.")
+
+    target_path = dest_path or os.path.basename(local_path)
+    with open(local_path, "rb") as f:
+        _client.storage.from_(bucket).upload(target_path, f, {"upsert": True})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "dependencies": {
     "framer-motion": "^12.23.12",
-    "lucide-react": "^0.539.0"
+    "lucide-react": "^0.539.0",
+    "@supabase/supabase-js": "^2.44.0"
   },
   "scripts": {
     "start": "node server.js"


### PR DESCRIPTION
## Summary
- add helper to upload files to Supabase storage
- pipeline uploads predictions csv to Supabase bucket
- server fetches prediction data from Supabase instead of local filesystem
- add `@supabase/supabase-js` dependency

## Testing
- `python -m py_compile backend/mlb_pred_pipeline.py backend/src/supabase_client.py`
- `node --check server.js`
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ea4249d48333a66cefb6d01e8a4c