### PR TITLE
Add workflow to run MLB prediction pipeline

### DIFF
--- a/.github/workflows/run-mlb-pipeline.yml
+++ b/.github/workflows/run-mlb-pipeline.yml
@@ -1,0 +1,26 @@
+name: Run MLB prediction pipeline
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  run-pipeline:
+    runs-on: ubuntu-latest
+    env:
+      ODDS_API_KEY: ${{ secrets.ODDS_API_KEY }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+      SUPABASE_STORAGE_BUCKET: ${{ secrets.SUPABASE_STORAGE_BUCKET }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run prediction pipeline
+      run: python backend/mlb_pred_pipeline.py

--- a/README.md
+++ b/README.md
@@ -23,11 +23,15 @@ available sportsbook odds.
 
    The pipeline writes predictions to `data/processed/games_today.csv` and, if
    the `SUPABASE_URL` and `SUPABASE_KEY` environment variables are set, also
-   publishes the results to a Supabase table for the frontend to consume.
+   publishes the results to a Supabase table for the frontend to consume. When
+   `SUPABASE_STORAGE_BUCKET` is set, required CSV inputs such as player IDs and
+   team schedules will be downloaded from that storage bucket instead of being
+   committed to the repository.
 
    ```bash
    export SUPABASE_URL="https://your-project.supabase.co"
    export SUPABASE_KEY="service_role_key"
+   export SUPABASE_STORAGE_BUCKET="mlb-data"
    python backend/mlb_pred_pipeline.py
    ```
 

--- a/backend/src/auto_predict.py
+++ b/backend/src/auto_predict.py
@@ -11,11 +11,18 @@ from src.feature_engineering import full_to_abbrev
 from src.pitchers import get_player_stats
 from src.lgbm_model import load_clf_model, FEATURES
 from src.fangraphs_stats import fg_team_snapshot
+from src.supabase_client import ensure_local_file
 
 HISTORY = "data/pred_history.csv"
 
 def load_processed_data(year: int) -> pd.DataFrame:
     path = f"data/processed/mlb_teams_schedules_{year}.csv"
+    bucket = os.getenv("SUPABASE_STORAGE_BUCKET")
+    if not os.path.exists(path) and bucket:
+        try:
+            ensure_local_file(bucket, f"processed/mlb_teams_schedules_{year}.csv", path)
+        except Exception as exc:
+            print(f"Warning: failed to download processed schedule from Supabase: {exc}")
     df = pd.read_csv(path, dtype={'Tm':str,'Opp':str}, parse_dates=['Date'])
     return df
 

--- a/backend/src/pitchers.py
+++ b/backend/src/pitchers.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import requests_cache
 import json
@@ -11,11 +12,20 @@ from bs4 import BeautifulSoup, Comment
 from pybaseball import playerid_lookup, statcast_pitcher, pitching_stats
 
 from src.war import get_pitcher_war_on_date
+from src.supabase_client import ensure_local_file
 
 requests_cache.install_cache('bbref_cache', expire_after=86400)
 session = requests_cache.CachedSession()
 
-pid_df = pd.read_csv("data/playerid_list.csv")  
+PID_CSV = "data/playerid_list.csv"
+_BUCKET = os.getenv("SUPABASE_STORAGE_BUCKET")
+if _BUCKET:
+    try:
+        ensure_local_file(_BUCKET, "playerid_list.csv", PID_CSV)
+    except Exception as exc:
+        print(f"Warning: failed to download playerid_list.csv from Supabase: {exc}")
+
+pid_df = pd.read_csv(PID_CSV)
 
 def get_all_boxscores(year: int) -> pd.DataFrame:
     url = f"https://www.baseball-reference.com/leagues/majors/{year}-schedule.shtml"

--- a/backend/src/supabase_client.py
+++ b/backend/src/supabase_client.py
@@ -5,6 +5,15 @@ import pandas as pd
 from supabase import Client, create_client
 
 
+def _require_client() -> Client:
+    """Return a configured Supabase client or raise an error."""
+    if _client is None:
+        raise RuntimeError(
+            "Supabase client is not configured. Set SUPABASE_URL and SUPABASE_KEY."
+        )
+    return _client
+
+
 _SUPABASE_URL: Optional[str] = os.getenv("SUPABASE_URL")
 _SUPABASE_KEY: Optional[str] = os.getenv("SUPABASE_KEY")
 
@@ -13,15 +22,24 @@ if _SUPABASE_URL and _SUPABASE_KEY:
     _client = create_client(_SUPABASE_URL, _SUPABASE_KEY)
 
 
+def ensure_local_file(bucket: str, storage_path: str, local_path: str) -> str:
+    """Download a file from a Supabase storage bucket if it is missing locally."""
+    if not os.path.exists(local_path):
+        client = _require_client()
+        data = client.storage.from_(bucket).download(storage_path)
+        os.makedirs(os.path.dirname(local_path), exist_ok=True)
+        with open(local_path, "wb") as f:
+            f.write(data)
+    return local_path
+
+
 def upsert_predictions(df: pd.DataFrame, table: str = "predictions") -> None:
     """Upload the day's predictions to Supabase and clear stale data."""
-    if _client is None:
-        raise RuntimeError("Supabase client is not configured. Set SUPABASE_URL and SUPABASE_KEY.")
-
+    client = _require_client()
     records = df.where(pd.notnull(df), None).to_dict("records")
     if records:
         if table == "predictions":
-            _client.table(table).delete().neq("id", 0).execute()
+            client.table(table).delete().neq("id", 0).execute()
         if table == "history":
-            _client.table(table).delete().neq("id", 0).execute()
-        _client.table(table).upsert(records).execute()
+            client.table(table).delete().neq("id", 0).execute()
+        client.table(table).upsert(records).execute()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+pandas
+numpy
+requests
+requests-cache
+python-dotenv
+beautifulsoup4
+pybaseball
+lightgbm
+scikit-learn
+joblib
+supabase
+tqdm


### PR DESCRIPTION
## Summary
- schedule GitHub Actions workflow to execute `backend/mlb_pred_pipeline.py`
- install Python dependencies from `requirements.txt`
- download CSV inputs from Supabase storage at runtime to avoid storing data in repo

## Testing
- `python -m py_compile backend/mlb_pred_pipeline.py`
- `python -m py_compile backend/src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa067c3fc88333b0d7748c38c07663