### PR TITLE
feat: add supabase auth and login flow

### DIFF
--- a/my-app/src/components/AuthButton.tsx
+++ b/my-app/src/components/AuthButton.tsx
@@ -11,10 +11,19 @@ export default function AuthButton() {
   };
 
   if (user) {
+    const displayName =
+      (user.user_metadata as { display_name?: string })?.display_name ||
+      user.email;
+
     return (
-      <Button variant="ghost" onClick={handleSignOut} className="gap-2">
-        Logout
-      </Button>
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium">
+          {displayName}
+        </span>
+        <Button variant="ghost" onClick={handleSignOut} className="gap-2">
+          Logout
+        </Button>
+      </div>
     );
   }
 

--- a/my-app/src/components/AuthButton.tsx
+++ b/my-app/src/components/AuthButton.tsx
@@ -1,0 +1,27 @@
+import { Button } from "./ui/button";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/lib/auth";
+
+export default function AuthButton() {
+  const { user } = useAuth();
+
+  const handleSignOut = async () => {
+    await supabase.auth.signOut();
+    window.location.href = "/";
+  };
+
+  if (user) {
+    return (
+      <Button variant="ghost" onClick={handleSignOut} className="gap-2">
+        Logout
+      </Button>
+    );
+  }
+
+  return (
+    <Button asChild variant="ghost" className="gap-2">
+      <a href="/login">Login</a>
+    </Button>
+  );
+}
+

--- a/my-app/src/lib/auth.tsx
+++ b/my-app/src/lib/auth.tsx
@@ -1,0 +1,47 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import type { Session, User } from "@supabase/supabase-js";
+import { supabase } from "./supabase";
+
+interface AuthContextValue {
+  user: User | null;
+  session: Session | null;
+  loading: boolean;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  session: null,
+  loading: true,
+});
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [session, setSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session);
+      setLoading(false);
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, sess) => {
+      setSession(sess);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user: session?.user ?? null, session, loading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);
+

--- a/my-app/src/main.tsx
+++ b/my-app/src/main.tsx
@@ -6,6 +6,7 @@ import HomeLanding from './pages/LandingPage.tsx'
 import Methodology from './pages/Methodology.tsx'
 import About from './pages/About.tsx'
 import Login from './pages/Login.tsx'
+import Signup from './pages/Signup.tsx'
 import { AuthProvider } from './lib/auth'
 
 const storedTheme = localStorage.getItem('theme')
@@ -26,6 +27,8 @@ const App = () => {
       return <About />
     case '/login':
       return <Login />;
+    case '/signup':
+      return <Signup />;
     default:
       return <HomeLanding />;
   }

--- a/my-app/src/main.tsx
+++ b/my-app/src/main.tsx
@@ -5,6 +5,8 @@ import SportsbookHome from './pages/MLB.tsx'
 import HomeLanding from './pages/LandingPage.tsx'
 import Methodology from './pages/Methodology.tsx'
 import About from './pages/About.tsx'
+import Login from './pages/Login.tsx'
+import { AuthProvider } from './lib/auth'
 
 const storedTheme = localStorage.getItem('theme')
 
@@ -22,6 +24,8 @@ const App = () => {
       return <Methodology />;
     case '/about':
       return <About />
+    case '/login':
+      return <Login />;
     default:
       return <HomeLanding />;
   }
@@ -31,6 +35,8 @@ export default App;
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>,
 )

--- a/my-app/src/pages/LandingPage.tsx
+++ b/my-app/src/pages/LandingPage.tsx
@@ -19,6 +19,7 @@ import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
 import { Input } from "../components/ui/input";
 import ThemeToggle from "../components/ThemeToggle";
+import AuthButton from "../components/AuthButton";
 
 // --- small helpers for the demo calculator ---
 const impliedFromAmerican = (odds?: number) => {
@@ -82,6 +83,7 @@ export default function HomeLanding() {
             <Button variant="ghost" className="gap-2" disabled><BiBasketball className="w-4 h-4"/> NBA <span className="opacity-60">(soon)</span></Button>
             <Button variant="ghost" className="gap-2" disabled><PiFootball className="w-4 h-4"/> NFL <span className="opacity-60">(soon)</span></Button>
             <Button asChild variant="ghost" className="gap-2"><a href="/about"><Info className="w-4 h-4"/> About</a></Button>
+            <AuthButton />
           </nav>
         </div>
       </header>

--- a/my-app/src/pages/Login.tsx
+++ b/my-app/src/pages/Login.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+export default function Login() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const signIn = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      setError(error.message);
+    } else {
+      window.location.href = "/mlb";
+    }
+  };
+
+  const signUp = async () => {
+    setError(null);
+    const { error } = await supabase.auth.signUp({ email, password });
+    if (error) {
+      setError(error.message);
+    } else {
+      setMessage("Check your email for a confirmation link.");
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardContent className="p-6">
+          <form className="space-y-4" onSubmit={signIn}>
+            <Input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+            <Input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+            {error && <div className="text-sm text-red-500">{error}</div>}
+            {message && <div className="text-sm text-green-600">{message}</div>}
+            <Button type="submit" className="w-full">
+              Sign In
+            </Button>
+            <Button type="button" variant="secondary" className="w-full" onClick={signUp}>
+              Sign Up
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/my-app/src/pages/Login.tsx
+++ b/my-app/src/pages/Login.tsx
@@ -46,6 +46,9 @@ export default function Login() {
             <Button asChild variant="secondary" className="w-full">
               <a href="/signup">Create Account</a>
             </Button>
+            <Button asChild variant="ghost" className="w-full">
+              <a href="/">Back to Home</a>
+            </Button>
           </form>
         </CardContent>
       </Card>

--- a/my-app/src/pages/MLB.tsx
+++ b/my-app/src/pages/MLB.tsx
@@ -10,6 +10,8 @@ import { Switch } from "../components/ui/switch";
 import { Badge } from "../components/ui/badge";
 import { supabase } from "../lib/supabase";
 import ThemeToggle from "../components/ThemeToggle";
+import AuthButton from "../components/AuthButton";
+import { useAuth } from "../lib/auth";
 
 // --- Types ---
 interface Prediction {
@@ -134,6 +136,8 @@ function runInternalTests() {
 
 // --- Component ---
 export default function SportsbookHome() {
+  const { user, loading: authLoading } = useAuth();
+
   const [data, setData] = useState<Prediction[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -379,6 +383,12 @@ export default function SportsbookHome() {
     URL.revokeObjectURL(url);
   };
 
+  useEffect(() => {
+    if (!authLoading && !user) {
+      window.location.href = "/login";
+    }
+  }, [authLoading, user]);
+
   const Header = () => (
     <header className="sticky top-0 z-30 backdrop-blur bg-white/70 dark:bg-neutral-900/70 border-b border-border">
         <div className="max-w-7xl mx-auto px-4 py-3 flex flex-col sm:flex-row items-center gap-3">
@@ -397,12 +407,13 @@ export default function SportsbookHome() {
             <Button variant="ghost" className="gap-2" disabled><BiBasketball className="w-4 h-4"/> NBA <span className="opacity-60">(soon)</span></Button>
             <Button variant="ghost" className="gap-2" disabled><PiFootball className="w-4 h-4"/> NFL <span className="opacity-60">(soon)</span></Button>
             <Button asChild variant="ghost" className="gap-2"><a href="/about"><Info className="w-4 h-4"/> About</a></Button>
+            <AuthButton />
           </nav>
         </div>
       </header>
   );
 
-  return (
+  return user ? (
     <div className="min-h-screen bg-gradient-to-b from-indigo-50 via-white to-emerald-50 dark:from-neutral-900 dark:via-neutral-950 dark:to-neutral-900 text-neutral-900 dark:text-neutral-100">
       <Header />
 
@@ -671,5 +682,5 @@ export default function SportsbookHome() {
         </footer>
       </main>
     </div>
-  );
+  ) : null;
 }

--- a/my-app/src/pages/Signup.tsx
+++ b/my-app/src/pages/Signup.tsx
@@ -4,19 +4,20 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 
-export default function Login() {
+export default function Signup() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
 
-  const signIn = async (e: React.FormEvent) => {
+  const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    const { error } = await supabase.auth.signUp({ email, password });
     if (error) {
       setError(error.message);
     } else {
-      window.location.href = "/mlb";
+      setMessage("Check your email for a confirmation link.");
     }
   };
 
@@ -24,7 +25,7 @@ export default function Login() {
     <div className="min-h-screen flex items-center justify-center p-4">
       <Card className="w-full max-w-md">
         <CardContent className="p-6">
-          <form className="space-y-4" onSubmit={signIn}>
+          <form className="space-y-4" onSubmit={handleSignUp}>
             <Input
               type="email"
               placeholder="Email"
@@ -40,11 +41,12 @@ export default function Login() {
               required
             />
             {error && <div className="text-sm text-red-500">{error}</div>}
+            {message && <div className="text-sm text-green-600">{message}</div>}
             <Button type="submit" className="w-full">
-              Sign In
+              Sign Up
             </Button>
             <Button asChild variant="secondary" className="w-full">
-              <a href="/signup">Create Account</a>
+              <a href="/login">Back to Login</a>
             </Button>
           </form>
         </CardContent>
@@ -52,4 +54,3 @@ export default function Login() {
     </div>
   );
 }
-

--- a/my-app/src/pages/Signup.tsx
+++ b/my-app/src/pages/Signup.tsx
@@ -7,13 +7,22 @@ import { Button } from "@/components/ui/button";
 export default function Signup() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [displayName, setDisplayName] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
 
   const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
-    const { error } = await supabase.auth.signUp({ email, password });
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: {
+        data: {
+          display_name: displayName,
+        },
+      },
+    });
     if (error) {
       setError(error.message);
     } else {
@@ -26,6 +35,12 @@ export default function Signup() {
       <Card className="w-full max-w-md">
         <CardContent className="p-6">
           <form className="space-y-4" onSubmit={handleSignUp}>
+            <Input
+              type="text"
+              placeholder="Display Name"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+            />
             <Input
               type="email"
               placeholder="Email"
@@ -47,6 +62,9 @@ export default function Signup() {
             </Button>
             <Button asChild variant="secondary" className="w-full">
               <a href="/login">Back to Login</a>
+            </Button>
+            <Button asChild variant="ghost" className="w-full">
+              <a href="/">Back to Home</a>
             </Button>
           </form>
         </CardContent>


### PR DESCRIPTION
## Summary
- add Supabase-powered AuthProvider and context hook
- implement login page and navbar login/logout button
- protect MLB predictions route by requiring authentication

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acb3ffd01883338c8dc73d635e02d1