### PR TITLE
feat: add client-side routing

### DIFF
--- a/my-app/package.json
+++ b/my-app/package.json
@@ -21,6 +21,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-icons": "^5.5.0",
+    "react-router-dom": "^6.23.1",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {

--- a/my-app/src/components/AuthButton.tsx
+++ b/my-app/src/components/AuthButton.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import { Button } from "./ui/button";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/lib/auth";
@@ -18,9 +19,11 @@ export default function AuthButton() {
     return () => document.removeEventListener("mousedown", handleClick);
   }, []);
 
+  const navigate = useNavigate();
+
   const handleSignOut = async () => {
     await supabase.auth.signOut();
-    window.location.href = "/";
+    navigate("/");
   };
 
   if (user) {
@@ -67,7 +70,7 @@ export default function AuthButton() {
 
   return (
     <Button asChild variant="ghost" className="gap-2">
-      <a href="/login">Login/Register</a>
+      <Link to="/login">Login/Register</Link>
     </Button>
   );
 }

--- a/my-app/src/components/NavBar.tsx
+++ b/my-app/src/components/NavBar.tsx
@@ -2,6 +2,7 @@ import { motion } from "framer-motion";
 import { HandCoins, Trophy, Info } from "lucide-react";
 import { BiBaseball, BiBasketball } from "react-icons/bi";
 import { PiFootball } from "react-icons/pi";
+import { Link } from "react-router-dom";
 import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";
 import ThemeToggle from "./ThemeToggle";
@@ -37,18 +38,18 @@ export default function NavBar({ active, showAuthButton = true }: NavBarProps) {
             variant="ghost"
             className={`gap-2 ${active === "home" ? activeClass : ""}`}
           >
-            <a href="/">
+            <Link to="/">
               <Trophy className="w-4 h-4" /> Home
-            </a>
+            </Link>
           </Button>
           <Button
             asChild
             variant="ghost"
             className={`gap-2 ${active === "mlb" ? activeClass : ""}`}
           >
-            <a href="/mlb">
+            <Link to="/mlb">
               <BiBaseball className="w-4 h-4" /> MLB
-            </a>
+            </Link>
           </Button>
           <Button variant="ghost" className="gap-2" disabled>
             <BiBasketball className="w-4 h-4" /> NBA <span className="opacity-60">(soon)</span>
@@ -61,9 +62,9 @@ export default function NavBar({ active, showAuthButton = true }: NavBarProps) {
             variant="ghost"
             className={`gap-2 ${active === "about" ? activeClass : ""}`}
           >
-            <a href="/about">
+            <Link to="/about">
               <Info className="w-4 h-4" /> About
-            </a>
+            </Link>
           </Button>
           {showAuthButton && <AuthButton />}
         </nav>

--- a/my-app/src/main.tsx
+++ b/my-app/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import SportsbookHome from './pages/MLB.tsx'
 import HomeLanding from './pages/LandingPage.tsx'
 import Methodology from './pages/Methodology.tsx'
@@ -17,22 +18,18 @@ if (storedTheme === 'dark' || (!storedTheme && window.matchMedia('(prefers-color
   document.documentElement.classList.remove('dark')
 }
 
-const App = () => {
-  switch (window.location.pathname) {
-    case '/mlb':
-      return <SportsbookHome />;
-    case '/methodology':
-      return <Methodology />;
-    case '/about':
-      return <About />
-    case '/login':
-      return <Login />;
-    case '/signup':
-      return <Signup />;
-    default:
-      return <HomeLanding />;
-  }
-};
+const App = () => (
+  <BrowserRouter>
+    <Routes>
+      <Route path="/" element={<HomeLanding />} />
+      <Route path="/mlb" element={<SportsbookHome />} />
+      <Route path="/methodology" element={<Methodology />} />
+      <Route path="/about" element={<About />} />
+      <Route path="/login" element={<Login />} />
+      <Route path="/signup" element={<Signup />} />
+    </Routes>
+  </BrowserRouter>
+);
 
 export default App;
 

--- a/my-app/src/pages/About.tsx
+++ b/my-app/src/pages/About.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent } from "../components/ui/card";
 import { ExternalLink } from "lucide-react";
+import { Link } from "react-router-dom";
 import NavBar from "../components/NavBar";
 
 export default function About() {
@@ -28,9 +29,9 @@ export default function About() {
         <footer className="mt-12 pb-10 text-sm text-neutral-600 dark:text-neutral-400 flex flex-wrap items-center gap-2">
           <span>© {new Date().getFullYear()} UpperHand</span>
           <span className="opacity-50">•</span>
-          <a href="/about" className="inline-flex items-center gap-1 hover:underline">About <ExternalLink className="w-3.5 h-3.5"/></a>
+          <Link to="/about" className="inline-flex items-center gap-1 hover:underline">About <ExternalLink className="w-3.5 h-3.5"/></Link>
           <span className="opacity-50">•</span>
-          <a href="/methodology" className="inline-flex items-center gap-1 hover:underline">Methodology <ExternalLink className="w-3.5 h-3.5"/></a>
+          <Link to="/methodology" className="inline-flex items-center gap-1 hover:underline">Methodology <ExternalLink className="w-3.5 h-3.5"/></Link>
         </footer>
       </main>
     </div>

--- a/my-app/src/pages/LandingPage.tsx
+++ b/my-app/src/pages/LandingPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { useAuth } from "../lib/auth";
 import { motion } from "framer-motion";
+import { Link } from "react-router-dom";
 import {
   Brain,
   BarChart3,
@@ -84,12 +85,14 @@ export default function HomeLanding() {
             <div className="flex flex-wrap gap-3 mt-5">
               <Button asChild size="lg" className="gap-2">
                 {user ? (
-                  <a href="/mlb"><BiBaseball className="w-4 h-4"/> Explore Today’s MLB Picks</a>
+                  <Link to="/mlb"><BiBaseball className="w-4 h-4"/> Explore Today’s MLB Picks</Link>
                 ) : (
-                  <a href="/signup"><CircleStar className="w-4 h-4"/>Register Now!</a>
+                  <Link to="/signup"><CircleStar className="w-4 h-4"/>Register Now!</Link>
                 )}
               </Button>
-              <Button asChild variant="secondary" size="lg" className="gap-2"><a href="/methodology"><Brain className="w-4 h-4"/> Methodology</a></Button>
+              <Button asChild variant="secondary" size="lg" className="gap-2">
+                <Link to="/methodology"><Brain className="w-4 h-4"/> Methodology</Link>
+              </Button>
             </div>
             <div className="mt-4 text-sm text-neutral-600 dark:text-neutral-400">Realtime slate, sortable edges, CSV export, and more.</div>
           </motion.div>
@@ -186,10 +189,10 @@ export default function HomeLanding() {
                 <p className="text-sm/relaxed text-white/90 mb-4">See today’s projections and recommended stakes right now.</p>
                 <Button asChild size="lg" variant="secondary" className="w-full bg-white/15 hover:bg-white/25 text-white border-white/30">
                   {user ? (
-                  <a href="/mlb"><BiBaseball className="w-4 h-4"/> Go to MLB Predictions</a>
-                ) : (
-                  <a href="/login"><BiBaseball className="w-4 h-4"/> Go to MLB Predictions</a>
-                )}
+                    <Link to="/mlb"><BiBaseball className="w-4 h-4"/> Go to MLB Predictions</Link>
+                  ) : (
+                    <Link to="/login"><BiBaseball className="w-4 h-4"/> Go to MLB Predictions</Link>
+                  )}
                 </Button>
                 <div className="text-xs text-white/80 mt-3 flex items-center gap-1">
                   <Info className="w-3.5 h-3.5"/> Not financial advice. For informational use only.
@@ -203,9 +206,9 @@ export default function HomeLanding() {
         <footer className="mt-12 pb-10 text-sm text-neutral-600 dark:text-neutral-400 flex flex-wrap items-center gap-2">
           <span>© {new Date().getFullYear()} UpperHand</span>
           <span className="opacity-50">•</span>
-          <a href="/about" className="inline-flex items-center gap-1 hover:underline">About <ExternalLink className="w-3.5 h-3.5"/></a>
+          <Link to="/about" className="inline-flex items-center gap-1 hover:underline">About <ExternalLink className="w-3.5 h-3.5"/></Link>
           <span className="opacity-50">•</span>
-          <a href="/methodology" className="inline-flex items-center gap-1 hover:underline">Methodology <ExternalLink className="w-3.5 h-3.5"/></a>
+          <Link to="/methodology" className="inline-flex items-center gap-1 hover:underline">Methodology <ExternalLink className="w-3.5 h-3.5"/></Link>
         </footer>
       </main>
     </div>

--- a/my-app/src/pages/Login.tsx
+++ b/my-app/src/pages/Login.tsx
@@ -3,6 +3,7 @@ import { supabase } from "@/lib/supabase";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Link, useNavigate } from "react-router-dom";
 import GoogleIcon from "@/assets/Google.svg"
 
 export default function Login() {
@@ -26,6 +27,8 @@ export default function Login() {
     }
   };
 
+  const navigate = useNavigate();
+
   const signIn = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
@@ -33,7 +36,7 @@ export default function Login() {
     if (error) {
       setError(error.message);
     } else {
-      window.location.href = "/mlb";
+      navigate("/mlb");
     }
   };
 
@@ -73,10 +76,10 @@ export default function Login() {
               Sign in with Google
             </Button>
             <Button asChild variant="secondary" className="w-full">
-              <a href="/signup">Create Account</a>
+              <Link to="/signup">Create Account</Link>
             </Button>
             <Button asChild variant="ghost" className="w-full">
-              <a href="/">Back to Home</a>
+              <Link to="/">Back to Home</Link>
             </Button>
           </form>
         </CardContent>

--- a/my-app/src/pages/MLB.tsx
+++ b/my-app/src/pages/MLB.tsx
@@ -9,6 +9,7 @@ import { Badge } from "../components/ui/badge";
 import { supabase } from "../lib/supabase";
 import { useAuth } from "../lib/auth";
 import NavBar from "../components/NavBar";
+import { Link, useNavigate } from "react-router-dom";
 
 // --- Types ---
 interface Prediction {
@@ -380,11 +381,12 @@ export default function SportsbookHome() {
     URL.revokeObjectURL(url);
   };
 
+  const navigate = useNavigate();
   useEffect(() => {
     if (!authLoading && !user) {
-      window.location.href = "/login";
+      navigate("/login");
     }
-  }, [authLoading, user]);
+  }, [authLoading, user, navigate]);
 
   return user ? (
     <div className="min-h-screen bg-gradient-to-b from-indigo-50 via-white to-emerald-50 dark:from-neutral-900 dark:via-neutral-950 dark:to-neutral-900 text-neutral-900 dark:text-neutral-100">
@@ -414,9 +416,9 @@ export default function SportsbookHome() {
             <div className="flex flex-wrap gap-3 mt-4">
               <Button onClick={downloadCsv} className="gap-2"><Download className="w-4 h-4"/> Export CSV</Button>
               <Button variant="secondary" onClick={() => window.location.reload()} className="gap-2"><RefreshCcw className="w-4 h-4"/> Refresh</Button>
-              <a href="/methodology" className="inline-flex items-center gap-2 text-indigo-600 hover:underline">
+              <Link to="/methodology" className="inline-flex items-center gap-2 text-indigo-600 hover:underline">
                 Methodology <ExternalLink className="w-4 h-4"/>
-              </a>
+              </Link>
             </div>
             {lastUpdated && (
               <p className="text-sm mt-2 text-neutral-600 dark:text-neutral-400">Updates every morning. Last updated: {new Date(lastUpdated).toLocaleString()}</p>
@@ -649,9 +651,9 @@ export default function SportsbookHome() {
         <footer className="mt-12 pb-10 text-sm text-neutral-600 dark:text-neutral-400 flex flex-wrap items-center gap-2">
           <span>© {new Date().getFullYear()} UpperHand</span>
           <span className="opacity-50">•</span>
-          <a href="/about" className="inline-flex items-center gap-1 hover:underline">About <ExternalLink className="w-3.5 h-3.5"/></a>
+          <Link to="/about" className="inline-flex items-center gap-1 hover:underline">About <ExternalLink className="w-3.5 h-3.5"/></Link>
           <span className="opacity-50">•</span>
-          <a href="/methodology" className="inline-flex items-center gap-1 hover:underline">Methodology <ExternalLink className="w-3.5 h-3.5"/></a>
+          <Link to="/methodology" className="inline-flex items-center gap-1 hover:underline">Methodology <ExternalLink className="w-3.5 h-3.5"/></Link>
         </footer>
       </main>
     </div>

--- a/my-app/src/pages/Methodology.tsx
+++ b/my-app/src/pages/Methodology.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent } from "../components/ui/card";
 import { ExternalLink } from "lucide-react";
+import { Link } from "react-router-dom";
 import NavBar from "../components/NavBar";
 
 export default function Methodology() {
@@ -34,9 +35,9 @@ export default function Methodology() {
         <footer className="mt-12 pb-10 text-sm text-neutral-600 dark:text-neutral-400 flex flex-wrap items-center gap-2">
           <span>© {new Date().getFullYear()} UpperHand</span>
           <span className="opacity-50">•</span>
-          <a href="/about" className="inline-flex items-center gap-1 hover:underline">About <ExternalLink className="w-3.5 h-3.5"/></a>
+          <Link to="/about" className="inline-flex items-center gap-1 hover:underline">About <ExternalLink className="w-3.5 h-3.5"/></Link>
           <span className="opacity-50">•</span>
-          <a href="/methodology" className="inline-flex items-center gap-1 hover:underline">Methodology <ExternalLink className="w-3.5 h-3.5"/></a>
+          <Link to="/methodology" className="inline-flex items-center gap-1 hover:underline">Methodology <ExternalLink className="w-3.5 h-3.5"/></Link>
         </footer>
       </main>
     </div>

--- a/my-app/src/pages/Register.tsx
+++ b/my-app/src/pages/Register.tsx
@@ -3,6 +3,7 @@ import { supabase } from "@/lib/supabase";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Link } from "react-router-dom";
 import GoogleIcon from "@/assets/Google.svg"
 
 export default function Signup() {
@@ -90,10 +91,10 @@ export default function Signup() {
               Sign up with Google
             </Button>
             <Button asChild variant="secondary" className="w-full">
-              <a href="/login">Already have an account?</a>
+              <Link to="/login">Already have an account?</Link>
             </Button>
             <Button asChild variant="ghost" className="w-full">
-              <a href="/">Back to Home</a>
+              <Link to="/">Back to Home</Link>
             </Button>
           </form>
         </CardContent>


### PR DESCRIPTION
## Summary
- add react-router-dom for client-side navigation
- use BrowserRouter and Link components throughout the app
- replace window.location redirects with useNavigate hooks

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad44db03988333a5315ae4841d3458