### PR TITLE
feat: use edge function for account deletion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 ODDS_API_KEY="key"
 SUPABASE_URL="https://your-project.supabase.co"
+SUPABASE_ANON_KEY="anon_public_key"
 SUPABASE_KEY="service_role_key"
 SUPABASE_BUCKET="mlb-data"

--- a/api/delete-account.js
+++ b/api/delete-account.js
@@ -1,6 +1,5 @@
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
-const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_KEY; // optional: for admin fallback
 
 const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN || "*"; // set to your site origin in prod
 
@@ -36,72 +35,23 @@ module.exports = async (req, res) => {
   }
 
   try {
-    // --- 1) Try self-delete with the user's access token
-    const selfDelete = await fetch(`${SUPABASE_URL}/auth/v1/user`, {
-      method: "DELETE",
+    const edgeRes = await fetch(`${SUPABASE_URL}/functions/v1/delete-user`, {
+      method: "POST",
       headers: {
         Authorization: `Bearer ${token}`,
         apikey: SUPABASE_ANON_KEY,
       },
     });
 
-    if (selfDelete.ok) {
-      return res.status(200).json({ success: true, mode: "self" });
+    const body = await edgeRes.json().catch(() => ({}));
+
+    if (edgeRes.ok) {
+      return res.status(200).json({ success: true });
     }
 
-    // Read body for diagnostics (don’t throw if not JSON)
-    const body = await selfDelete.json().catch(() => ({}));
-    const message =
-      body.error_description || body.error || `Self-delete failed with ${selfDelete.status}`;
-    console.warn("Self-delete failed:", message);
-
-    // --- 2) Optional admin fallback (requires service role key)
-    if (SUPABASE_SERVICE_ROLE_KEY) {
-      // First get the current user to learn their ID
-      const whoami = await fetch(`${SUPABASE_URL}/auth/v1/user`, {
-        method: "GET",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          apikey: SUPABASE_ANON_KEY,
-        },
-      });
-
-      if (!whoami.ok) {
-        const wbody = await whoami.json().catch(() => ({}));
-        const wmsg = wbody.error_description || wbody.error || `whoami failed ${whoami.status}`;
-        console.error("Admin fallback: failed to fetch user:", wmsg);
-        return res.status(selfDelete.status).json({ error: message });
-      }
-
-      const user = await whoami.json().catch(() => null);
-      const userId = user?.id;
-      if (!userId) {
-        console.error("Admin fallback: user id missing in whoami response");
-        return res.status(selfDelete.status).json({ error: message });
-      }
-
-      // Admin delete
-      const adminDelete = await fetch(`${SUPABASE_URL}/auth/v1/admin/users/${userId}`, {
-        method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
-          apikey: SUPABASE_ANON_KEY,
-        },
-      });
-
-      if (adminDelete.ok) {
-        return res.status(200).json({ success: true, mode: "admin" });
-      } else {
-        const abody = await adminDelete.json().catch(() => ({}));
-        const amsg =
-          abody.error_description || abody.error || `Admin delete failed ${adminDelete.status}`;
-        console.error("Admin delete failed:", amsg);
-        return res.status(500).json({ error: "Failed to delete account." });
-      }
-    }
-
-    // No admin fallback configured → bubble up self-delete failure
-    return res.status(selfDelete.status).json({ error: message });
+    const message = body.error || body.message || `Delete failed with ${edgeRes.status}`;
+    console.error("Edge self-delete failed:", message);
+    return res.status(edgeRes.status).json({ error: message });
   } catch (err) {
     console.error("Unhandled error in delete-account:", err);
     return res.status(500).json({ error: "Failed to delete account." });

--- a/supabase/functions/delete-user/index.ts
+++ b/supabase/functions/delete-user/index.ts
@@ -1,0 +1,57 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.55.0";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? Deno.env.get("SUPABASE_KEY");
+
+  if (!supabaseUrl || !serviceKey) {
+    return new Response(
+      JSON.stringify({ error: "Server misconfiguration" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+
+  const authHeader = req.headers.get("Authorization") || "";
+  const token = authHeader.replace("Bearer ", "");
+  if (!token) {
+    return new Response(
+      JSON.stringify({ error: "Unauthorized" }),
+      { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+
+  const supabase = createClient(supabaseUrl, serviceKey);
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser(token);
+  if (error || !user) {
+    return new Response(
+      JSON.stringify({ error: "Unauthorized" }),
+      { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+
+  const { error: deleteError } = await supabase.auth.admin.deleteUser(user.id);
+  if (deleteError) {
+    console.error("Failed to delete user:", deleteError);
+    return new Response(
+      JSON.stringify({ error: "Failed to delete user" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+
+  return new Response(
+    JSON.stringify({ success: true }),
+    { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+  );
+});


### PR DESCRIPTION
## Summary
- simplify `/api/delete-account` to call Supabase edge function
- add `delete-user` edge function leveraging service role
- document `SUPABASE_ANON_KEY` in environment example

## Testing
- `npm test` *(fails: Missing script: "test" )*

------
https://chatgpt.com/codex/tasks/task_e_68ae13b355408333b941a9dfc70c7031